### PR TITLE
coffee-script as a devDependency + prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+lib/*.js

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test:
-	@mocha --reporter list --growl --compilers coffee:coffee-script tests/mocha.coffee
+	@./node_modules/.bin/mocha --reporter list --growl --compilers coffee:coffee-script tests/mocha.coffee
 
 oldtest:
 	@node tests/barista.test.js
 
 autotest:
-	@cd lib; mocha -w --reporter list --growl --compilers coffee:coffee-script ../tests/mocha.coffee
+	@cd lib; ../node_modules/.bin/mocha -w --reporter list --growl --compilers coffee:coffee-script ../tests/mocha.coffee

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-require('coffee-script')
+try { require('coffee-script'); }
+catch (e) {}
 exports.Router = require('./lib/router').Router;

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "author": "Kieran Huggins <kieran@kieran.ca>",
   "repository": "git://github.com/kieran/barista",
   "main": "./index.js",
+  "scripts": {
+    "prepublish": "./node_modules/.bin/coffee -c ./lib/",
+    "test": "./node_modules/.bin/mocha --reporter list --growl --compilers coffee:coffee-script tests/mocha.coffee",
+    "autotest": "cd lib; ../node_modules/.bin/mocha -w --reporter list --growl --compilers coffee:coffee-script ../tests/mocha.coffee"
+  },
   "engines": { "node": ">= 0.4.0" },
   "dependencies": {
-    "inflection": "*",
+    "inflection": "*"
+  },
+  "devDependencies": {
     "coffee-script": "*",
     "mocha": "*"
   }


### PR DESCRIPTION
Hi,

as it's suggested in the npm documentation ( https://npmjs.org/doc/scripts.html ), it would be nice if coffee-script wasn't mandatory with the npm release. Same thing for mocha.

Also, I see you're using a Makefile. I'm not very opinionated about that, but theses tasks could as well be put in the package.json's scripts section.

What do you think ? I would send a pull request if you're ok with that.

Do you have plan to release the coffe-script version soon ?
I have a feature I would like to suggest and implement directly in the coffe-script version.
